### PR TITLE
use date object, not iso string

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = (incomingOptions) => {
           softDelete: true,
         });
         const patch = {};
-        patch[options.columnName] = new Date().toISOString();
+        patch[options.columnName] = new Date();
         return this.patch(patch);
       }
 


### PR DESCRIPTION
Using the `.toISOString` func actually is not valid in some later versions of MySQL due to the format. It is much better to use a `Date` and let the orm handle the actual string formatting. 